### PR TITLE
Allow a line gradient to move along the x-axis. 

### DIFF
--- a/ChartsDemo-iOS/Swift/Demos/LineChart1ViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/LineChart1ViewController.swift
@@ -135,10 +135,10 @@ class LineChart1ViewController: DemoBaseViewController {
         if dataSet.isDrawLineWithGradientEnabled {
             dataSet.lineDashLengths = nil
             dataSet.highlightLineDashLengths = nil
-            dataSet.setColors(.green, .purple, .white)
+            dataSet.setColors(.black, .red, .white)
             dataSet.setCircleColor(.black)
             dataSet.gradientPositions = [0, 40, 100]
-            dataSet.lineWidth = 5
+            dataSet.lineWidth = 5  // wider lineWidth to see the gradient
             dataSet.circleRadius = 3
             dataSet.drawCircleHoleEnabled = false
             dataSet.valueFont = .systemFont(ofSize: 9)

--- a/ChartsDemo-iOS/Swift/Demos/LineChart1ViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/LineChart1ViewController.swift
@@ -135,10 +135,10 @@ class LineChart1ViewController: DemoBaseViewController {
         if dataSet.isDrawLineWithGradientEnabled {
             dataSet.lineDashLengths = nil
             dataSet.highlightLineDashLengths = nil
-            dataSet.setColors(.black, .red, .white)
+            dataSet.setColors(.green, .purple, .white)
             dataSet.setCircleColor(.black)
             dataSet.gradientPositions = [0, 40, 100]
-            dataSet.lineWidth = 1
+            dataSet.lineWidth = 5
             dataSet.circleRadius = 3
             dataSet.drawCircleHoleEnabled = false
             dataSet.valueFont = .systemFont(ofSize: 9)

--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -16,10 +16,7 @@ import CoreGraphics
     import UIKit
 #endif
 
-public enum GradientDirection {
-    case horizontal
-    case veritcal
-}
+public typealias GradientDirection = Legend.Orientation
 
 open class LineChartRenderer: LineRadarRenderer
 {

--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -16,6 +16,10 @@ import CoreGraphics
     import UIKit
 #endif
 
+public enum GradientDirection {
+    case horizontal
+    case veritcal
+}
 
 open class LineChartRenderer: LineRadarRenderer
 {
@@ -444,7 +448,7 @@ open class LineChartRenderer: LineRadarRenderer
             if !firstPoint
             {
                 if dataSet.isDrawLineWithGradientEnabled {
-                    drawGradientLine(context: context, dataSet: dataSet, spline: path, matrix: valueToPixelMatrix)
+                    drawGradientLine(context: context, dataSet: dataSet, spline: path, matrix: valueToPixelMatrix, colorDirection: .horizontal)
                 } else {
                     context.beginPath()
                     context.addPath(path)
@@ -815,7 +819,7 @@ open class LineChartRenderer: LineRadarRenderer
         context.restoreGState()
     }
 
-    func drawGradientLine(context: CGContext, dataSet: LineChartDataSetProtocol, spline: CGPath, matrix: CGAffineTransform)
+    func drawGradientLine(context: CGContext, dataSet: LineChartDataSetProtocol, spline: CGPath, matrix: CGAffineTransform, colorDirection: GradientDirection = .horizontal)
     {
         guard let gradientPositions = dataSet.gradientPositions else
         {
@@ -834,12 +838,13 @@ open class LineChartRenderer: LineRadarRenderer
             return
         }
 
-        let gradientStart = CGPoint(x: 0, y: boundingBox.minY)
-        let gradientEnd = CGPoint(x: 0, y: boundingBox.maxY)
+        let gradientStart = colorDirection == .horizontal ? CGPoint(x: boundingBox.minX, y: 0) : CGPoint(x: 0, y: boundingBox.minY)
+        let gradientEnd = colorDirection == .horizontal ? CGPoint(x: boundingBox.maxX, y: 0) : CGPoint(x: 0, y: boundingBox.maxY)
         var gradientColorComponents: [CGFloat] = []
         var gradientLocations: [CGFloat] = []
 
-        for position in gradientPositions.reversed()
+        let gradPositions: [CGFloat] = colorDirection == .horizontal ? gradientPositions : gradientPositions.reversed()
+        for position in gradPositions
         {
             let location = CGPoint(x: boundingBox.minX, y: position)
                 .applying(matrix)


### PR DESCRIPTION
![img_0118](https://user-images.githubusercontent.com/17268/45517811-3e061a00-b764-11e8-9ccc-c0c267a608a9.PNG)

### Goals :soccer:
In addition to the linear gradient option, this PR adds the ability to set the axis along which the gradient should run. 

### Implementation Details :construction:
- Added a new parameter to the lower-level draw that let's you set the direction
- Re-using the `Legend.Orientation` enum for axis
